### PR TITLE
upgrade to nom 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ doc = false
 
 [dependencies]
 colorify = "0.2"
-nom = "1.2"
+nom = "^2.0"
 rustyline = "0.2"

--- a/src/bin/command.rs
+++ b/src/bin/command.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::str::{self, FromStr};
-use nom::{IResult, eof, space, digit, alphanumeric, is_space};
+use nom::{IResult, space, digit, alphanumeric, is_space};
 
 #[derive(Debug, Clone)]
 pub enum Command {
@@ -20,8 +20,8 @@ pub enum Command {
 
 named!(
     command<Command>,
-    chain!(
-        c: alt_complete!(
+    terminated!(
+        alt_complete!(
             exit |
             set_interpreter |
             unset_interpreter |
@@ -31,9 +31,8 @@ named!(
             reset |
             step |
             repeat
-        ) ~
-        eof, // force eof after matching command
-        || c
+        ),
+        eof!() // force eof after matching command
     )
 );
 


### PR DESCRIPTION
Hi!

as a part of the release process for nom 2.0, I selected a few crates to test it with, and make sure everything works correctly.

I'm happy to tell you that this crate built fine with nom 2.0 out of the box, no need to change anything!

If you want more information on this release, see the blogpost: https://unhandledexpression.com/2016/11/25/this-year-in-nom-2-0-is-here/ (reddit discussion: https://www.reddit.com/r/rust/comments/5espfm/this_year_in_nom_20_is_here/ )

There are a few new features that could be of interest for this project :)